### PR TITLE
feat(ehentai): 添加画廊归档功能并更新帮助文档

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -53,6 +53,12 @@
         "hint": "Cookie中的igneous值 默认值：无",
         "default": ""
     },
+    "request_cookies_sk": {
+        "description": "Cookie: sk",
+        "type": "string",
+        "hint": "Cookie中的sk值 默认值：无",
+        "default": ""
+    },
     "request_proxies": {
         "description": "代理设置",
         "type": "string",

--- a/utils/config_manager.py
+++ b/utils/config_manager.py
@@ -82,6 +82,7 @@ def load_config(config: dict, config_path: Optional[Union[str, Path]] = None) ->
         "request_cookies_ipb_member_id": ["request", "cookies", "ipb_member_id"],
         "request_cookies_ipb_pass_hash": ["request", "cookies", "ipb_pass_hash"],
         "request_cookies_igneous": ["request", "cookies", "igneous"],
+        "request_cookies_sk": ["request", "cookies", "sk"], 
         "request_proxies": ["request", "proxies"],
         "request_concurrency": ["request", "concurrency"],
         "request_max_retries": ["request", "max_retries"],


### PR DESCRIPTION
添加归档eh命令用于获取画廊归档下载链接，支持通过画廊链接或搜索结果序号获取
在downloader.py中实现get_archive_url方法处理归档链接获取逻辑


cookies配置中存在sk时可以调用e站本身的配置和过滤项，进一步过滤搜索结果，也能使返回的标题显示为日语而非英语和罗马音。
